### PR TITLE
New config option: TTN_RADIO_RST_KEEP_ASSERTED

### DIFF
--- a/Kconfig
+++ b/Kconfig
@@ -55,6 +55,13 @@ config TTN_SPI_FREQ
     help
         SPI frequency to communicate between ESP32 and SX127x radio chip
 
+config TTN_RADIO_RST_KEEP_ASSERTED
+        bool "Keep RST pin asserted instead of floating"
+        default n
+        help
+          Some hardware needs RST pin to be always high for LoRa chip to function
+
+
 config TTN_BG_TASK_PRIO
     int "Background task priority"
     default 10

--- a/src/hal/hal_esp32.cpp
+++ b/src/hal/hal_esp32.cpp
@@ -128,9 +128,16 @@ void hal_pin_rst(u1_t val)
         gpio_set_direction(ttn_hal.pinRst, GPIO_MODE_OUTPUT);
     }
     else
-    { // keep pin floating
+    {
+#ifdef CONFIG_TTN_RADIO_RST_KEEP_ASSERTED
+      // drive up the pin because the hardware is nonstandard
+        gpio_set_level(ttn_hal.pinRst, 1);
+        gpio_set_direction(ttn_hal.pinRst, GPIO_MODE_OUTPUT);
+#else
+      // keep pin floating
         gpio_set_level(ttn_hal.pinRst, val);
         gpio_set_direction(ttn_hal.pinRst, GPIO_MODE_INPUT);
+#endif
     }
 }
 


### PR DESCRIPTION
as described in https://github.com/manuelbl/ttn-esp32/issues/23 , this option enables a workaround for nonstandard hardware