### PR TITLE
Add lmic controls

### DIFF
--- a/include/TheThingsNetwork.h
+++ b/include/TheThingsNetwork.h
@@ -21,20 +21,6 @@
  */
 #define TTN_NOT_CONNECTED 0xff
 
-class LMIC_Controls
-{
-  public:
-    void  disableChannel (uint8_t channel);
-    void  enableSubBand(uint8_t band);
-    void  enableChannel(uint8_t channel);
-    void  disableSubBand(uint8_t band);
-    void  selectSubBand(uint8_t band);
-
-    //void  setDrTxpow   (dr_t dr, s1_t txpow);  // set default/start DR/txpow
-    //void  setAdrMode   (bit_t enabled);        // set ADR mode (if mobile turn off)
-};
-
-
 typedef uint8_t port_t;
 
 /**
@@ -239,6 +225,79 @@ public:
      * @param rssiCal RSSI calibration value, in dB
      */
     void setRSSICal(int8_t rssiCal);
+
+    /**
+     * @brief Disables a channel via the underlying LMIC library.
+     *
+     * This will fail to build if this component has not been configured 
+     * (idf.py menuconfig / make menuconfig )
+     *
+     * @param channel unsigned integer indicating the channel number to disable
+     * @return true success
+     * @return false otherwise
+     */
+    bool disableChannel (uint8_t channel);
+
+    /**
+     * @brief Enables a sub band (group of 8 channels).
+     *
+     * This function is used to enable a consecutive group of 8 predefined channels.  This
+     * function works through the underlying LMIC library.
+     * This will fail to build if this component has not been configured 
+     * (idf.py menuconfig / make menuconfig )
+     *
+     * @param band unsigned integer indicating which block of channels to enable
+     * @return true success
+     * @return false otherwise
+     */
+    bool enableSubBand(uint8_t band);
+
+    /**
+     * @brief Enables a channel via the underlying LMIC library.
+     *
+     * This will fail to build if this component has not been configured 
+     * (idf.py menuconfig / make menuconfig )
+     *
+     * @param channel unsigned integer indicating which channel to enable
+     * @return true success
+     * @return false otherwise
+     */
+    bool enableChannel(uint8_t channel);
+
+    /**
+     * @brief Disables a sub band (group of 8 channels).
+     *
+     * This function is used to disable a consecutive group of 8 predefined channels.  This
+     * function works through the underlying LMIC library.
+     * This will fail to build if this component has not been configured 
+     * (idf.py menuconfig / make menuconfig )
+     *
+     *
+     * @param band unsigned integer indicating which block of channels to disable
+     * @return true success
+     * @return false otherwise
+     */
+    bool disableSubBand(uint8_t band);
+
+    /**
+     * @brief Selects a single sub band (group of 8 channels) to be active at a time.
+     *
+     * This function is used to exclusively enable a block of consecutive channels.  It operates
+     * via LMIC_disableSubBand() and LMIC_enableSubBand(), enabling only the selected band.
+     * This works well when being used with gateways that only support a subset of all LoRa
+     * channels (many consumer gateways only support up to 8 channels at a time).
+     * This will fail to build if this component has not been configured 
+     * (idf.py menuconfig / make menuconfig )
+     *
+     *
+     * @param band unsigned integer indicating which block of channels to use
+     * @return true success
+     * @return false otherwise
+     */
+    bool selectSubBand(uint8_t band);
+
+    //void  setDrTxpow   (dr_t dr, s1_t txpow);  // set default/start DR/txpow
+    //void  setAdrMode   (bit_t enabled);        // set ADR mode (if mobile turn off)
 
 private:
     TTNMessageCallback messageCallback;

--- a/include/TheThingsNetwork.h
+++ b/include/TheThingsNetwork.h
@@ -21,6 +21,19 @@
  */
 #define TTN_NOT_CONNECTED 0xff
 
+class LMIC_Controls
+{
+  public:
+    void  disableChannel (uint8_t channel);
+    void  enableSubBand(uint8_t band);
+    void  enableChannel(uint8_t channel);
+    void  disableSubBand(uint8_t band);
+    void  selectSubBand(uint8_t band);
+
+    //void  setDrTxpow   (dr_t dr, s1_t txpow);  // set default/start DR/txpow
+    //void  setAdrMode   (bit_t enabled);        // set ADR mode (if mobile turn off)
+};
+
 
 typedef uint8_t port_t;
 

--- a/src/TheThingsNetwork.cpp
+++ b/src/TheThingsNetwork.cpp
@@ -19,6 +19,12 @@
 #include "TTNProvisioning.h"
 #include "TTNLogging.h"
 
+void LMIC_Controls::disableChannel(uint8_t channel){ LMIC_disableChannel( channel ); }
+void LMIC_Controls::enableSubBand(uint8_t band){ LMIC_enableSubBand( band ); }
+void LMIC_Controls::enableChannel(uint8_t channel){ LMIC_enableChannel( channel ); }
+void LMIC_Controls::disableSubBand(uint8_t band){ LMIC_disableSubBand( band ); }
+void LMIC_Controls::selectSubBand(uint8_t band){ LMIC_selectSubBand( band ); }
+
 
 /**
  * @brief Reason the user code is waiting

--- a/src/TheThingsNetwork.cpp
+++ b/src/TheThingsNetwork.cpp
@@ -19,13 +19,6 @@
 #include "TTNProvisioning.h"
 #include "TTNLogging.h"
 
-void LMIC_Controls::disableChannel(uint8_t channel){ LMIC_disableChannel( channel ); }
-void LMIC_Controls::enableSubBand(uint8_t band){ LMIC_enableSubBand( band ); }
-void LMIC_Controls::enableChannel(uint8_t channel){ LMIC_enableChannel( channel ); }
-void LMIC_Controls::disableSubBand(uint8_t band){ LMIC_disableSubBand( band ); }
-void LMIC_Controls::selectSubBand(uint8_t band){ LMIC_selectSubBand( band ); }
-
-
 /**
  * @brief Reason the user code is waiting
  */
@@ -202,6 +195,7 @@ bool TheThingsNetwork::joinCore()
     ttn_hal.enterCriticalSection();
     waitingReason = eWaitingForJoin;
     LMIC_startJoining();
+    LMIC_selectSubBand( 1 );
     ttn_hal.wakeUp();
     ttn_hal.leaveCriticalSection();
 
@@ -270,6 +264,12 @@ void TheThingsNetwork::setRSSICal(int8_t rssiCal)
 {
     ttn_hal.rssiCal = rssiCal;
 }
+
+bool TheThingsNetwork::disableChannel(uint8_t channel){ return !LMIC_disableChannel( channel ); }
+bool TheThingsNetwork::enableSubBand(uint8_t band){ return !LMIC_enableSubBand( band ); }
+bool TheThingsNetwork::enableChannel(uint8_t channel){ return !LMIC_enableChannel( channel ); }
+bool TheThingsNetwork::disableSubBand(uint8_t band){ return !LMIC_disableSubBand( band ); }
+bool TheThingsNetwork::selectSubBand(uint8_t band){ return !LMIC_selectSubBand( band ); }
 
 
 // --- Callbacks ---


### PR DESCRIPTION
This resolves an issue where the library hid the underlying LMIC controls from the end user, and defaulted to enabling all the LoRaWAN channels.  This is an issue as not all gateways support the full LoRaWAN band plan, and this will cause a large packet loss when communicating with such gateways (effectively `(total_region_channels - supported_channels) / total_region_channels`).  This is very likely to be encounter during normal use, as the library indicates it is targeting The Things Network (TTN), which explicitly does not use the full LoRaWAN allocated spectrum.

LoRaWAN bandplan: https://lora-alliance.org/sites/default/files/2018-04/lorawantm_regional_parameters_v1.1rb_-_final.pdf#page=15
TTN bandplan: https://www.thethingsnetwork.org/docs/lorawan/frequency-plans.html.