### PR TITLE
Prevent hal_ticks() from going into .text region

### DIFF
--- a/src/hal/hal_esp32.cpp
+++ b/src/hal/hal_esp32.cpp
@@ -346,7 +346,7 @@ bool HAL_ESP32::wait(WaitKind waitKind)
 }
 
 // Gets current time in LMIC ticks
-u4_t hal_ticks()
+u4_t IRAM_ATTR hal_ticks()
 {
     // LMIC tick unit: 16µs
     // esp_timer unit: 1µs


### PR DESCRIPTION
Fixes #33 

This will fix an issue when the flash is disabled (due to OTA update for example) and the cpu crashes with cache disabled access from ISR (when TTN executes)