### PR TITLE
Fix include errors

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,6 +9,7 @@ set(COMPONENT_ADD_INCLUDEDIRS
 )
 set(COMPONENT_REQUIRES
     nvs_flash
+    mbedtls
 )
 
 register_component()

--- a/src/hal/hal_esp32.c
+++ b/src/hal/hal_esp32.c
@@ -20,7 +20,6 @@
 #include "driver/gpio.h"
 #include "esp_rom_gpio.h"
 #include "driver/spi_master.h"
-#include "driver/timer.h"
 #include "esp_timer.h"
 #include "esp_log.h"
 #include <time.h>

--- a/src/hal/hal_esp32.c
+++ b/src/hal/hal_esp32.c
@@ -18,6 +18,7 @@
 #include "freertos/task.h"
 #include "freertos/semphr.h"
 #include "driver/gpio.h"
+#include "esp_rom_gpio.h"
 #include "driver/spi_master.h"
 #include "driver/timer.h"
 #include "esp_timer.h"
@@ -116,30 +117,30 @@ void init_io(void)
     ASSERT(pin_dio0 != LMIC_UNUSED_PIN);
     ASSERT(pin_dio1 != LMIC_UNUSED_PIN);
 
-    gpio_pad_select_gpio(pin_nss);
+    esp_rom_gpio_pad_select_gpio(pin_nss);
     gpio_set_level(pin_nss, 0);
     gpio_set_direction(pin_nss, GPIO_MODE_OUTPUT);
 
     if (pin_rx_tx != LMIC_UNUSED_PIN)
     {
-        gpio_pad_select_gpio(pin_rx_tx);
+        esp_rom_gpio_pad_select_gpio(pin_rx_tx);
         gpio_set_level(pin_rx_tx, 0);
         gpio_set_direction(pin_rx_tx, GPIO_MODE_OUTPUT);
     }
 
     if (pin_rst != LMIC_UNUSED_PIN)
     {
-        gpio_pad_select_gpio(pin_rst);
+        esp_rom_gpio_pad_select_gpio(pin_rst);
         gpio_set_level(pin_rst, 0);
         gpio_set_direction(pin_rst, GPIO_MODE_OUTPUT);
     }
 
     // DIO pins with interrupt handlers
-    gpio_pad_select_gpio(pin_dio0);
+    esp_rom_gpio_pad_select_gpio(pin_dio0);
     gpio_set_direction(pin_dio0, GPIO_MODE_INPUT);
     gpio_set_intr_type(pin_dio0, GPIO_INTR_POSEDGE);
 
-    gpio_pad_select_gpio(pin_dio1);
+    esp_rom_gpio_pad_select_gpio(pin_dio1);
     gpio_set_direction(pin_dio1, GPIO_MODE_INPUT);
     gpio_set_intr_type(pin_dio1, GPIO_INTR_POSEDGE);
 


### PR DESCRIPTION
When compiling as component of ESP-IDF v4.3.2 I got the following compilation errors:

```
$(pwd)/components/ttn-esp32/src/hal/hal_esp32.c:119:5: error: implicit declaration of function 'gpio_pad_select_gpio'; did you mean 'esp_rom_gpio_pad_select_gpio'? [-Werror=implicit-function-declaration]
     gpio_pad_select_gpio(pin_nss);
     ^~~~~~~~~~~~~~~~~~~~
     esp_rom_gpio_pad_select_gpio
```
```
$(pwd)/components/ttn-esp32/src/aes/mbedtls_aes.c:13:10: fatal error: mbedtls/aes.h: No such file or directory
 #include "mbedtls/aes.h"
          ^~~~~~~~~~~~~~~
```

This PR fixes both of them.