### PR TITLE
fix configPower for sx1272

### DIFF
--- a/src/lmic/radio.c
+++ b/src/lmic/radio.c
@@ -670,9 +670,9 @@ static void configPower () {
     if (req_pw >= 20) {
         policy = LMICHAL_radio_tx_power_policy_20dBm;
             eff_pw = 20;
-    } else if (eff_pw >= 14) {
+    } else if (req_pw >= 14) {
         policy = LMICHAL_radio_tx_power_policy_paboost;
-        if (eff_pw > 17) {
+        if (req_pw > 17) {
             eff_pw = 17;
         } else {
             eff_pw = req_pw;


### PR DESCRIPTION
The function configPower is not compiling when using CFG_sx1272_radio. The error is the following:

```bash
ttn-esp32/src/lmic/radio.c: In function 'configPower':
ttn-esp32/src/lmic/radio.c:673:15: error: 'eff_pw' may be used uninitialized in this function [-Werror=maybe-uninitialized]
     } else if (eff_pw >= 14) {
               ^
cc1: some warnings being treated as errors
```
To fix it, I followed the logic that I saw it is executed when using `CFG_sx1276_radio`, where the value of `eff_pw` depends of `req_pw` and no of its own value.
