### PR TITLE
fix compilation issues against esp-idf v5.1-dev-187-g5b11895700

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,6 +10,9 @@ set(COMPONENT_ADD_INCLUDEDIRS
 set(COMPONENT_REQUIRES
     nvs_flash
     mbedtls
+    driver
+    esp_event
+    esp_timer
 )
 
 register_component()

--- a/src/ttn_provisioning.c
+++ b/src/ttn_provisioning.c
@@ -15,6 +15,7 @@
 #include "esp_event.h"
 #include "esp_log.h"
 #include "esp_system.h"
+#include "esp_mac.h"
 #include "freertos/FreeRTOS.h"
 #include "hal/hal_esp32.h"
 #include "lmic/lmic.h"


### PR DESCRIPTION
hi, 

thanks for providing this component! got me up and running within a day! i appreciate your work. 

i had problems compiling the component against esp-idf v5.1-dev-187-g5b11895700 - i added ttn-esp32 to the global components folder in my main esp-idf directory. this was tested on kubuntu 22.04.1. i'll probably test on another OS soon. 

- changes in CMakeLists.txt fix "spi_master.h not found" and then a few follow-up missing headers.  
- the extra include in /src/ttn_provisioning.c fixes an issue with a mac address related function (sorry, i can't remember the name)

i may have butchered things here or gotten them wrong, but the changes seem to have resolved the issues for me :)  


cheers!