### PR TITLE
make this function IRAM_ATTR because it's used from IRQ

### DIFF
--- a/src/hal/hal_esp32.c
+++ b/src/hal/hal_esp32.c
@@ -308,7 +308,7 @@ int64_t os_time_to_esp_time(int64_t esp_now, uint32_t os_time)
     return esp_time;
 }
 
-int64_t get_current_time()
+int64_t IRAM_ATTR get_current_time()
 {
     return esp_timer_get_time() + time_offset;
 }


### PR DESCRIPTION
otherwise crash with "Cache disabled but cached memory region accessed" if flash is busy